### PR TITLE
Improve the compatibility with TS environments

### DIFF
--- a/example_project/karma.conf.ts
+++ b/example_project/karma.conf.ts
@@ -7,9 +7,8 @@ declare module 'karma' {
     karmaTypescriptConfig?: KarmaTypescriptConfig | undefined
   }
 
-  interface Config {
+  interface Config extends ConfigOptions {
     preset?: string
-    reporters: string[]
   }
 }
 
@@ -220,11 +219,11 @@ function setupBrowserStack(config: Config) {
   }
 
   config.set({
-    reporters: [...config.reporters, 'BrowserStack'],
+    reporters: [...(config.reporters || []), 'BrowserStack'],
     browsers: Object.keys(customLaunchers),
     customLaunchers,
     concurrency: 5,
-    plugins: [karmaPlugin, 'karma-*'],
+    plugins: [...(config.plugins || []), karmaPlugin],
     retryLimit: 3,
     captureTimeout: 15_000,
     browserStack: {

--- a/node/browser.d.ts
+++ b/node/browser.d.ts
@@ -4,7 +4,7 @@
  *
  * TypeScript supports this field if the `moduleResolution` compiler option is set to `node16`,
  * which is not always possible.
- * When the default TypeScript configuration supports `node16`, this file should be removed.
+ * When the default TypeScript configuration supports `node16`, this file should be removed in favor of `exports`.
  */
 
 export * from './dist/index_browser'

--- a/node/browser.d.ts
+++ b/node/browser.d.ts
@@ -1,0 +1,10 @@
+/*
+ * This file is a temporary workaround for TypeScript environments that don't support `exports` field of `package.json`.
+ * More about this field: https://www.typescriptlang.org/docs/handbook/esm-node.html#packagejson-exports-imports-and-self-referencing
+ *
+ * TypeScript supports this field if the `moduleResolution` compiler option is set to `node16`,
+ * which is not always possible.
+ * When the default TypeScript configuration supports `node16`, this file should be removed.
+ */
+
+export * from './dist/index_browser'

--- a/node/browser.js
+++ b/node/browser.js
@@ -4,7 +4,7 @@
  *
  * A not supporting platform is the `karma-typescript` dependency which relies on the `resolve` sub-dependency.
  * A `resolve` issue for supporting `exports`: https://github.com/browserify/resolve/issues/222
- * When the issue is resolved and `karma-typescript` updates the sub-dependency, this file should be removed.
+ * When the issue is resolved and the sub-dependency is updated, this file should be removed in favor of `exports`.
  */
 
 module.exports = require('./dist/index_browser')

--- a/node/node.d.ts
+++ b/node/node.d.ts
@@ -1,0 +1,5 @@
+/*
+ * See browser.d.ts
+ */
+
+export * from './dist/index_node'

--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fpjs-incubator/broyster",
   "description": "Test tools",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "keywords": [
     "test",
     "tools",

--- a/node/package.json
+++ b/node/package.json
@@ -18,16 +18,6 @@
     "url": "https://github.com/fingerprintjs/broyster/issues"
   },
   "homepage": "https://github.com/fingerprintjs/broyster",
-  "exports": {
-    "./browser": {
-      "require": "./dist/index_browser.js",
-      "types": "./dist/index_browser.d.ts"
-    },
-    "./node": {
-      "require": "./dist/index_node.js",
-      "types": "./dist/index_node.d.ts"
-    }
-  },
   "sideEffects": false,
   "files": [
     "dist",

--- a/node/package.json
+++ b/node/package.json
@@ -31,7 +31,9 @@
   "sideEffects": false,
   "files": [
     "dist",
+    "browser.d.ts",
     "browser.js",
+    "node.d.ts",
     "node.js"
   ],
   "scripts": {

--- a/node/readme.md
+++ b/node/readme.md
@@ -17,8 +17,6 @@ import * as broysterForNode from '@fpjs-incubator/broyster/node'
 
 ## Usage
 
-The pacakge requires nodeResolution in `tsconfig.json` to *node16*.
-
 This package exports the following:
 
 - `@fpjs-incubator/broyster/node`:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es6", // The TypeScript library is both for Node.js and browsers
-    "moduleResolution": "node16",
+    "moduleResolution": "node",
     "removeComments": false,
     "resolveJsonModule": true,
     "importHelpers": true,


### PR DESCRIPTION
Now it is not necessary to set `moduleResolution` to `node16` in `tsconfig.json`.

I've also bumped the package version because I'm going to publish it immediately.