### PR TITLE
Make the options be readonly

### DIFF
--- a/node/src/karma_plugin.ts
+++ b/node/src/karma_plugin.ts
@@ -5,6 +5,7 @@ import { makeBrowserStackSessionsManager } from './browserstack_sessions_manager
 import { BrowserStackLauncher } from './launcher'
 import { InlinePluginDef } from 'karma'
 import { BrowserStackReporter } from './browserstack_reporter'
+import type { FirefoxProfile } from './webdriver_factory';
 
 const karmaPlugin: InlinePluginDef = {
   'launcher:BrowserStack': ['type', BrowserStackLauncher],
@@ -28,9 +29,9 @@ declare module 'karma' {
   interface CustomLauncher {
     name?: string | undefined
     osVersion?: string | undefined
-    deviceName?: string | string[] | undefined
+    deviceName?: string | readonly string[] | undefined
     browserVersion?: string | null | undefined
-    firefoxCapabilities?: Array<[string, string | number | boolean]>
+    firefoxCapabilities?: FirefoxProfile
     useHttps?: boolean | undefined
     //extraSettings?: string[] | undefined; //TODO things like timezone, locale
   }

--- a/node/src/karma_plugin.ts
+++ b/node/src/karma_plugin.ts
@@ -5,7 +5,7 @@ import { makeBrowserStackSessionsManager } from './browserstack_sessions_manager
 import { BrowserStackLauncher } from './launcher'
 import { InlinePluginDef } from 'karma'
 import { BrowserStackReporter } from './browserstack_reporter'
-import type { FirefoxProfile } from './webdriver_factory';
+import type { FirefoxProfile } from './webdriver_factory'
 
 const karmaPlugin: InlinePluginDef = {
   'launcher:BrowserStack': ['type', BrowserStackLauncher],

--- a/node/src/launcher.ts
+++ b/node/src/launcher.ts
@@ -32,7 +32,7 @@ export function BrowserStackLauncher(
   }
   const device =
     args.browserVersion ??
-    (Array.isArray(args.deviceName) ? 'on any of ' + args.deviceName.join(', ') : args.deviceName)
+    (args.deviceName instanceof Array ? 'on any of ' + args.deviceName.join(', ') : args.deviceName)
   makeName(device)
 
   let browser: WebDriver

--- a/node/src/webdriver_factory.ts
+++ b/node/src/webdriver_factory.ts
@@ -5,13 +5,15 @@ import * as chrome from 'selenium-webdriver/chrome'
 import * as webdriver from 'selenium-webdriver'
 import { SessionCapabilities } from './session_capabilities'
 
+export type FirefoxProfile = ReadonlyArray<readonly [string, string | number | boolean]>
+
 export class WebDriverFactory {
   private static url = 'https://hub-cloud.browserstack.com/wd/hub'
 
   static createFromOptions(
     options: chrome.Options | firefox.Options | safari.Options | edge.Options,
     browserStack: SessionCapabilities,
-    firefoxProfile?: Array<[string, string | number | boolean]>,
+    firefoxProfile?: FirefoxProfile,
   ) {
     const builder = new webdriver.Builder().usingServer(this.url)
     switch (options.getBrowserName()?.toLowerCase()) {


### PR DESCRIPTION
Allows writing Karma configuration in TypeScript like this:

```diff
{
  platform: 'Windows',
  osVersion: '10',
  browserName: 'Firefox',
  browserVersion: '67',
  useHttps: true,
- firefoxCapabilities: [['security.csp.enable', true] as [string, boolean]],
+ firefoxCapabilities: [['security.csp.enable', true]] as const,
}
```