### PR TITLE
add allowing to specify a local identifier

### DIFF
--- a/node/src/browserstack_local_manager.ts
+++ b/node/src/browserstack_local_manager.ts
@@ -8,13 +8,13 @@ export class BrowserStackLocalManager {
   bsLocal: browserStack.Local = new browserStack.Local()
   switchPromise = Promise.resolve()
 
-  run(logger: Logger): Promise<void> {
+  run(logger: Logger, localIdentifier?: string | undefined): Promise<void> {
     if (!this.isRunning) {
       this.isRunning = true
       const bsAccesskey = getBrowserStackAccessKey()
       const bsLocalArgs = {
         key: bsAccesskey,
-        localIdentifier: undefined,
+        localIdentifier: localIdentifier,
         forceLocal: true,
         force: true,
       }

--- a/node/src/browserstack_session_factory.ts
+++ b/node/src/browserstack_session_factory.ts
@@ -14,6 +14,7 @@ export class BrowserStackSessionFactory {
   private _build: string
   private _capsFactory: CapabilitiesFactory
   private _idleTimeout: number
+  private _localIdentifier: string | undefined
 
   constructor(config: ConfigOptions) {
     if (!config.browserStack) {
@@ -21,6 +22,7 @@ export class BrowserStackSessionFactory {
     }
     this._username = getBrowserStackUserName()
     this._accessKey = getBrowserStackAccessKey()
+    this._localIdentifier = config.browserStack.localIdentifier
     this._project = config.browserStack.project
     this._build = config.browserStack.build.toString()
     this._idleTimeout = config.browserStack.idleTimeout ?? 60_000
@@ -66,6 +68,7 @@ export class BrowserStackSessionFactory {
       this._idleTimeout,
       browser.osVersion,
       browser.browserVersion,
+      this._localIdentifier,
     )
     log.debug('created capabilities: ' + JSON.stringify(caps))
     const opts = OptionsBuilder.create(browser.browserName, browser.flags)

--- a/node/src/bstack_options.ts
+++ b/node/src/bstack_options.ts
@@ -9,4 +9,5 @@ export interface BstackOptions {
   userName: string
   accessKey: string
   idleTimeout: number
+  localIdentifier?: string | undefined
 }

--- a/node/src/capabilities_factory.ts
+++ b/node/src/capabilities_factory.ts
@@ -19,6 +19,7 @@ export class CapabilitiesFactory {
     idleTimeout: number,
     osVersion?: string | undefined,
     browserVersion?: string | null | undefined,
+    localIdentifier?: string | undefined,
   ): SessionCapabilities {
     return {
       'bstack:options': {
@@ -32,6 +33,7 @@ export class CapabilitiesFactory {
         userName: this._username,
         accessKey: this._accessKey,
         idleTimeout: idleTimeout,
+        localIdentifier: localIdentifier,
       },
       browserName: browserName?.toLowerCase(),
       browserVersion: browserVersion || 'latest',

--- a/node/src/karma_plugin.ts
+++ b/node/src/karma_plugin.ts
@@ -23,6 +23,7 @@ declare module 'karma' {
       build: string | number
       idleTimeout?: number
       queueTimeout?: number
+      localIdentifier?: string | undefined
     }
   }
 


### PR DESCRIPTION
I discovered this when working with matrixes. Looks like a matrix job will need this in order to be able to run all tests. It's not a problem of having multiple BStack local binaries (technically there was only 1 as the other ones would be killed) but them being "unmarked". From what I have discovered, passing in a localIdentifier allows to create multiple tunnels without any conflicts, and thus it will allow running inside a matrix.