### PR TITLE
Update BrowserStack dependencies and debug capabilities

### DIFF
--- a/example_project/karma.conf.ts
+++ b/example_project/karma.conf.ts
@@ -162,7 +162,7 @@ const browsers = {
     platform: 'iOS',
     osVersion: '17',
     browserName: 'Safari',
-    useHttps: false,
+    useHttps: true,
     flags: [BrowserFlags.MobileUserAgent],
   },
 }

--- a/example_project/src/dom.test.ts
+++ b/example_project/src/dom.test.ts
@@ -28,9 +28,8 @@ describe('DOM', () => {
         const result = new UAParser().getResult()
         const isSafari = /^(Mobile )?Safari$/.test(result.browser.name ?? '')
         const isMacOS = result.os.name === 'Mac OS'
-        const isIOS = result.os.name === 'iOS'
         const browserVersion = parseInt(result.browser.version ?? '0')
-        return isSafari && ((isMacOS && browserVersion >= 15) || (isIOS && browserVersion >= 17))
+        return isSafari && isMacOS && browserVersion >= 15
       }
     })
   })

--- a/node/package.json
+++ b/node/package.json
@@ -37,8 +37,8 @@
   "dependencies": {
     "tslib": "^2.4.1",
     "selenium-webdriver": "^4.7.0",
-    "browserstack-local": "^1.5.1",
-    "browserstack": "~1.5.1",
+    "browserstack-local": "^1.5.5",
+    "browserstack": "~1.6.1",
     "async-lock": "^1.4.0"
   }
 }

--- a/node/src/browserstack_capabilities_factory.ts
+++ b/node/src/browserstack_capabilities_factory.ts
@@ -29,6 +29,11 @@ export class BrowserStackCapabilitiesFactory {
         accessKey: this._credentials.accessKey,
         idleTimeout: idleTimeout,
         localIdentifier: localIdentifier,
+        networkLogs: true,
+        networkLogsOptions: {
+          captureContent: 'true',
+        },
+        consoleLogs: 'verbose',
       },
       browserName: browserName?.toLowerCase(),
       browserVersion: browserVersion || 'latest',

--- a/node/src/browserstack_session_capabilities.ts
+++ b/node/src/browserstack_session_capabilities.ts
@@ -1,7 +1,7 @@
 import { BstackOptions } from './bstack_options'
 
 export interface BrowserStackSessionCapabilities {
-  'bstack:options': BstackOptions & Record<string, unknown>
+  'bstack:options': BstackOptions
   browserName?: string | undefined
   browserVersion?: string | undefined
   acceptInsecureCerts: boolean

--- a/node/src/browserstack_session_capabilities.ts
+++ b/node/src/browserstack_session_capabilities.ts
@@ -1,7 +1,7 @@
 import { BstackOptions } from './bstack_options'
 
 export interface BrowserStackSessionCapabilities {
-  'bstack:options': BstackOptions
+  'bstack:options': BstackOptions & Record<string, unknown>
   browserName?: string | undefined
   browserVersion?: string | undefined
   acceptInsecureCerts: boolean

--- a/node/src/bstack_options.ts
+++ b/node/src/bstack_options.ts
@@ -10,4 +10,11 @@ export interface BstackOptions {
   accessKey: string
   idleTimeout: number
   localIdentifier?: string | undefined
+  networkLogs?: boolean
+  networkLogsOptions?: NetworkLogsOptions
+  consoleLogs?: string
+}
+
+export interface NetworkLogsOptions {
+  captureContent: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -779,10 +779,10 @@ browserslist@^4.21.3:
     node-releases "^2.0.6"
     update-browserslist-db "^1.0.9"
 
-browserstack-local@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/browserstack-local/-/browserstack-local-1.5.1.tgz#0d424474cc2b74a9d9a22d00a2282941ff636f34"
-  integrity sha512-T/wxyWDzvBHbDvl7fZKpFU7mYze6nrUkBhNy+d+8bXBqgQX10HTYvajIGO0wb49oGSLCPM0CMZTV/s7e6LF0sA==
+browserstack-local@^1.5.5:
+  version "1.5.5"
+  resolved "https://registry.yarnpkg.com/browserstack-local/-/browserstack-local-1.5.5.tgz#f36b625f3b8bfd053f673d85fd1082f2d0759693"
+  integrity sha512-jKne7yosrMcptj3hqxp36TP9k0ZW2sCqhyurX24rUL4G3eT7OLgv+CSQN8iq5dtkv5IK+g+v8fWvsiC/S9KxMg==
   dependencies:
     agent-base "^6.0.2"
     https-proxy-agent "^5.0.1"
@@ -790,10 +790,10 @@ browserstack-local@^1.5.1:
     ps-tree "=1.2.0"
     temp-fs "^0.9.9"
 
-browserstack@~1.5.1:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/browserstack/-/browserstack-1.5.3.tgz#93ab48799a12ef99dbd074dd595410ddb196a7ac"
-  integrity sha512-AO+mECXsW4QcqC9bxwM29O7qWa7bJT94uBFzeb5brylIQwawuEziwq20dPYbins95GlWzOawgyDNdjYAo32EKg==
+browserstack@~1.6.1:
+  version "1.6.1"
+  resolved "https://registry.yarnpkg.com/browserstack/-/browserstack-1.6.1.tgz#e051f9733ec3b507659f395c7a4765a1b1e358b3"
+  integrity sha512-GxtFjpIaKdbAyzHfFDKixKO8IBT7wR3NjbzrGc78nNs/Ciys9wU3/nBtsqsWv5nDSrdI5tz0peKuzCPuNXNUiw==
   dependencies:
     https-proxy-agent "^2.2.1"
 


### PR DESCRIPTION
This allows running mobile Safari 17 in HTTPS mode