### PR TITLE
fix: The Karma configuration doesn't work if `node_modules` is excluded in `tsconfig.json`

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fpjs-incubator/broyster",
   "description": "Test tools",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "keywords": [
     "test",
     "tools",


### PR DESCRIPTION
The problem arises only in [the BotD CI pipeline](https://github.com/fingerprintjs/BotD/actions/runs/6689675294/job/18173595333?pr=150#step:13:12)