### PR TITLE
Add Safari 18 to the opinionated Karma configuration

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fpjs-incubator/broyster",
   "description": "Test tools",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "keywords": [
     "test",
     "tools",

--- a/node/readme.md
+++ b/node/readme.md
@@ -47,6 +47,7 @@ useHttps: true
 ```
 
 _deviceType_ is used only on iOS and allows to choose from `iPhone` (default) and `iPad`.
+You don't need to set a specific device name, the launcher chooses a device automatically. Same on Android.
 
 ```js
   Android11_ChromeLatest: {
@@ -58,8 +59,6 @@ _deviceType_ is used only on iOS and allows to choose from `iPhone` (default) an
   },
 ```
 
-You don't need to set a specific device name, the launcher chooses a device automatically. Same on Android.
-
 _firefoxCapabilities_ an array of extra capabilities specifically for Firefox.
 
 ```js
@@ -70,13 +69,16 @@ firefoxCapabilities: [
 ],
 ```
 
+_osVersion_ selects the given OS version and also it's beta counterpart. For example, setting the OS version to `17` will choose either `17` or `17 Beta`.
+
 ### Reporters
 
 There is a dedicated reporter that will mark successful tests as passed in BrowserStack.
 
 ```js
-  config.set({
-    reporters: [...config.reporters, 'BrowserStack'],
+config.set({
+  reporters: [...config.reporters, 'BrowserStack'],
+})
 ```
 
 ### BrowserStack specific settings

--- a/node/src/browserstack_browsers.ts
+++ b/node/src/browserstack_browsers.ts
@@ -54,7 +54,13 @@ export function makeBrowserStackBrowsers(browserStackCredentials: BrowserStackCr
 }
 
 function doesOSVersionMatch(browser: Browser, expectedOSVersion: string) {
-  return browser.os_version === expectedOSVersion
+  return (
+    // Direct match
+    browser.os_version === expectedOSVersion ||
+    // Beta version match
+    (browser.os_version.startsWith(expectedOSVersion) &&
+      /^[ \-_]beta$/i.test(browser.os_version.slice(expectedOSVersion.length)))
+  )
 }
 
 function doesDeviceTypeMatch(browser: Browser, expectedDeviceType: string) {

--- a/node/src/browserstack_session_factory.ts
+++ b/node/src/browserstack_session_factory.ts
@@ -33,7 +33,7 @@ export class BrowserStackSessionFactory {
 
   public async createBrowser(
     browser: CustomLauncher,
-    deviceName: string | null,
+    deviceName: string | undefined,
     id: string,
     log: Logger,
   ): Promise<WebDriver> {
@@ -44,7 +44,7 @@ export class BrowserStackSessionFactory {
         this._build,
         id,
         this._project,
-        deviceName ?? undefined,
+        deviceName,
         browser.platform,
         this._idleTimeout,
         browser.osVersion,

--- a/node/src/karma_configuration.ts
+++ b/node/src/karma_configuration.ts
@@ -209,12 +209,12 @@ const browserstackBrowsers = {
   Windows11_EdgeLatest: { platform: 'Windows', osVersion: '11', browserName: 'Edge', browserVersion: 'latest-beta', useHttps: true },
   'OSX10.14_Safari12': { platform: 'OS X', osVersion: 'Mojave', browserName: 'Safari', browserVersion: '12', useHttps: true },
   OSX12_Safari15: { platform: 'OS X', osVersion: 'Monterey', browserName: 'Safari', browserVersion: '15', useHttps: false },
-  OSX14_Safari17: { platform: 'OS X', osVersion: 'Sonoma', browserName: 'Safari', browserVersion: '17', useHttps: false },
-  OSX14_ChromeLatest: { platform: 'OS X', osVersion: 'Sonoma', browserName: 'Chrome', browserVersion: 'latest-beta', useHttps: true },
-  // OSX14_ChromeLatest_Incognito: { platform: 'OS X', osVersion: 'Sonoma', browserName: 'Chrome', browserVersion: 'latest-beta, ...chromeIncognitoCapabilities },
-  OSX14_FirefoxLatest: { platform: 'OS X', osVersion: 'Sonoma', browserName: 'Firefox', browserVersion: 'latest-beta', useHttps: true },
-  // OSX14_FirefoxLatest_Incognito: { platform: 'OS X', osVersion: 'Sonoma', browserName: 'Firefox', browserVersion: 'latest-beta, ...firefoxIncognitoCapabilities },
-  OSX14_EdgeLatest: { platform: 'OS X', osVersion: 'Sonoma', browserName: 'Edge', browserVersion: 'latest-beta', useHttps: true },
+  OSX15_Safari18: { platform: 'OS X', osVersion: 'Sequoia', browserName: 'Safari', browserVersion: '18', useHttps: false },
+  OSX15_ChromeLatest: { platform: 'OS X', osVersion: 'Sequoia', browserName: 'Chrome', browserVersion: 'latest-beta', useHttps: true },
+  // OSX15_ChromeLatest_Incognito: { platform: 'OS X', osVersion: 'Sequoia', browserName: 'Chrome', browserVersion: 'latest-beta, ...chromeIncognitoCapabilities },
+  OSX15_FirefoxLatest: { platform: 'OS X', osVersion: 'Sequoia', browserName: 'Firefox', browserVersion: 'latest-beta', useHttps: true },
+  // OSX15_FirefoxLatest_Incognito: { platform: 'OS X', osVersion: 'Sequoia', browserName: 'Firefox', browserVersion: 'latest-beta, ...firefoxIncognitoCapabilities },
+  OSX15_EdgeLatest: { platform: 'OS X', osVersion: 'Sequoia', browserName: 'Edge', browserVersion: 'latest-beta', useHttps: true },
   Android13_ChromeLatest: { platform: 'Android', osVersion: '13.0', browserName: 'Chrome', browserVersion: 'latest-beta', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
   iOS12_Safari: { platform: 'iOS', osVersion: '12', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
   iOS13_Safari: { platform: 'iOS', osVersion: '13', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
@@ -222,6 +222,7 @@ const browserstackBrowsers = {
   iOS15_Safari: { platform: 'iOS', osVersion: '15', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
   iOS16_Safari: { platform: 'iOS', osVersion: '16', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
   iOS17_Safari: { platform: 'iOS', osVersion: '17', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
+  iOS18_Safari: { platform: 'iOS', osVersion: '18 Beta', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
 }
 /* eslint-enable max-len */
 

--- a/node/src/karma_configuration.ts
+++ b/node/src/karma_configuration.ts
@@ -222,7 +222,7 @@ const browserstackBrowsers = {
   iOS15_Safari: { platform: 'iOS', osVersion: '15', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
   iOS16_Safari: { platform: 'iOS', osVersion: '16', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
   iOS17_Safari: { platform: 'iOS', osVersion: '17', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
-  iOS18_Safari: { platform: 'iOS', osVersion: '18 Beta', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
+  iOS18_Safari: { platform: 'iOS', osVersion: '18', browserName: 'Safari', useHttps: true, flags: [BrowserFlags.MobileUserAgent] },
 }
 /* eslint-enable max-len */
 

--- a/node/src/karma_plugin.ts
+++ b/node/src/karma_plugin.ts
@@ -34,6 +34,7 @@ declare module 'karma' {
 
   interface CustomLauncher {
     name?: string | undefined
+    /** Actually required, but left optional to avoid clashes with launcher types provided by other Karma plugins */
     osVersion?: string | undefined
     deviceType?: 'iPhone' | 'iPad' | undefined
     browserVersion?: string | null | undefined

--- a/node/src/launcher.ts
+++ b/node/src/launcher.ts
@@ -66,7 +66,7 @@ export function BrowserStackLauncher(
 
       log.debug(`creating browser with attributes: ${JSON.stringify(args)}`)
       log.debug(`attempt: ${startAttempt}`)
-      log.debug(`device name override: ${deviceName}`)
+      log.debug(`device name: ${deviceName}`)
       log.debug(`OS version override: ${osVersion}`)
 
       startAttempt += 1
@@ -171,8 +171,7 @@ async function getSuitableDevices(
   const devices: SuitableDevice[] = rawDevices
     ? rawDevices.map((device) => ({ name: device.device ?? undefined, osVersion: device.os_version }))
     : [{ name: undefined, osVersion: args.osVersion }]
-  // todo: Debug level
-  log.info(`devices suitable for attributes ${JSON.stringify(args)}: ${JSON.stringify(devices)}`)
+  log.debug(`devices suitable for attributes ${JSON.stringify(args)}: ${JSON.stringify(devices)}`)
 
   return devices
 }


### PR DESCRIPTION
Besides adding Safari 18 to the list, this PR makes the Karma launcher automatically switch the iOS version `18` to `18 Beta` if iOS `18` is unavailable on BrowserStack. This works with any OS and any OS version. This feature is needed to avoid configuration update when BrowserStack starts supporting iOS 18 and stops supporting iOS 18 Beta.

This PR bumps the Node package version to 0.2.1 to prepare for the release.