### PR TITLE
Improve the contributing guide

### DIFF
--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+support@fingerprint.com.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/contributing.md
+++ b/contributing.md
@@ -1,16 +1,70 @@
 # Contributing to Broyster
 
-## Working with the code
+Thanks for taking the time to contribute!
+Here you can find ways to make Broyster better, as well as tips and guidelines.
 
-Make sure you have [Yarn](https://yarnpkg.com) installed.
+This project and everyone participating in it is governed by the [Code of Conduct](code_of_conduct.md).
+By participating, you are expected to uphold this code.
 
-### Development
+## How you can contribute
 
-The project is a [Karma](https://karma-runner.github.io) plugin that provides a launcher that uses Selenium WebDriver and BrowserStack for tests as well as a reporter, and a retry metchanism for [Jasmine](https://jasmine.github.io) tests.
-Broyster comes with an example project including tests aimed at testing the essential features, but feel free to add your own as you see fit.
+### Reporting an issue
+
+If you've noticed a bug, have an idea or a question,
+feel free to [create an issue](https://github.com/fingerprintjs/broyster/issues/new/choose) or [start a discussion](https://github.com/fingerprintjs/broyster/discussions/new/choose).
+
+Before you start, please [search](https://github.com/search?q=repo%3Afingerprintjs%2Fbroyster) for your topic.
+There is a chance it has already been discussed.
+
+When you create an issue, please provide all the information needed to reproduce your situation, it will help us solve your issue faster.
+If you want to share a piece of code or the library output with us, please wrap it in a ` ``` ` block and make sure you include all the information.
+
+### Creating a pull request
+
+If you want to fix a bug or make any other code contribution, please [create a pull request](https://docs.github.com/en/get-started/exploring-projects-on-github/contributing-to-a-project).
+
+After you clone the repository, check the [Working with code](#working-with-code) section to learn how to run, check, and build the code.
+
+In order for us to review and accept your code contributions, please follow these rules:
+- Your code quality should be at least as good as the code you modify.
+- Your code style (syntax, naming, coding patterns, etc) should follow the Broyster style.
+- All the checks described in the [Working with code](#working-with-code) section must pass successfully.
+  You may create a draft pull request in this repository to run the checks automatically by GitHub Actions,
+  but the tests won't run on BrowserStack until a Broyster maintainer approves them.
+- Broyster comes with an [example project](example_project) including tests aimed at testing the essential features.
+  If you add a new feature, please add it to the example project.
+  It will allow to test your new feature and show its usage example to other developers.
+- The changes should be backward compatible, ensuring Broyster users continue to use the library without any modifications.
+- Don't add dependencies (such as Node packages) unless necessary.
+- Don't make changes unrelated to the stated purpose of your pull request. Please strive to introduce as few changes as possible.
+- Don't change Broyster code style, its TypeScript configuration, or other subjective things.
+
+If you want to do something more complex than fixing a small bug, or if you're not sure if your changes meet the project requirements, please [start a discussion](https://github.com/fingerprintjs/broyster/discussions/new/choose).
+We encourage starting a discussion if you want to propose violating a rule from this guide.
+Doing so ensures we discuss all opinions, creating a good contribution experience for everyone.
+
+### Helping with existing issues
+
+If you want to help, but don't know where to start, take a look at the ["help wanted" issues](https://github.com/fingerprintjs/broyster/labels/help%20wanted).
+You can help by sharing knowledge or creating a pull request.
+Feel free to ask questions in the issues if you need more details.
+
+## Working with code
+
+This section describes how to deploy the repository locally, make changes to the code, and verify your work.
+
+First, make sure you have [Git](https://git-scm.com), [Node.js](https://nodejs.org) and [Yarn](https://yarnpkg.com) installed.
+Then clone the repository and install the dependencies:
+
+```bash
+git clone https://github.com/fingerprintjs/broyster.git
+cd broyster
+yarn install
+```
 
 ### Code style
 
+Follow the repository's code style.
 The code style is controlled by [ESLint](https://eslint.org) and [Prettier](https://prettier.io).
 Run to check that the code style is ok:
 
@@ -27,14 +81,17 @@ yarn lint:fix
 
 ### How to build
 
-To build the distribution files of the library, run:
+To build the distribution files of the Node package, run:
 
 ```bash
-yarn install
+# Build once:
+yarn --cwd node build
+
+# Or build once and then rebuild when the code changes:
 yarn --cwd node build:watch
 ```
 
-The results will be placed in the `dist` folder by default.
+The files will be saved to the `node/dist` directory.
 
 ### Pitfalls
 
@@ -43,18 +100,16 @@ For some problems you will need to dig into Karma or Jasmine to figure out if an
 
 ### How to test
 
-The project contains an example project that contains tests.
+The repository contains an [example project](example_project) that contains tests.
 To run the tests in a browser on your machine, build the project:
 
 ```bash
-yarn install
 yarn --cwd node build:watch
 ```
 
-and run:
+and run in a separate terminal tab or window:
 
 ```bash
-# Run example tests in local browsers
 yarn --cwd example_project test:local
 ```
 
@@ -66,10 +121,14 @@ BROWSERSTACK_USERNAME=your-username BROWSERSTACK_ACCESS_KEY=your-key yarn --cwd 
 ```
 
 If you face `Error: spawn Unknown system error -86` on macOS, try installing Rosetta:
-
 ```bash
 softwareupdate --install-rosetta
 ```
 
 Alternatively, make a PR to this repository, the test will run on BrowserStack automatically.
-But the test won't run when the PR is made from a fork repository, in this case a member will run the tests manually.
+But the test won't run when the PR is made from a fork repository, in this case, a member will run the tests manually.
+
+BrowserStack sessions are unstable, so a session can fail for no reason;
+restart the testing when you see no clear errors related to the tests.
+If you run the test command multiple times in parallel, BrowserStack will lose access to the Karma server
+(for some reason), which will cause the tests to hang infinitely, so try to run a single test command at once.

--- a/readme.md
+++ b/readme.md
@@ -35,3 +35,8 @@ yarn --cwd example_project test:local
 # For Linux, macOS and WSL (Linux on Windows)
 BROWSERSTACK_USERNAME=your-username BROWSERSTACK_ACCESS_KEY=your-key yarn --cwd example_project test:browserstack
 ```
+
+## Contributing
+
+See the [Contribution guidelines](contributing.md) to learn how to contribute to the project or run the project locally.
+Please read it carefully before making a pull request.


### PR DESCRIPTION
The goal of the change is making contributing to BotD simpler to outside contributors. The updated contributing guide tells how one can help the project, and specifies requirements for outside contributions.

The PR adapts [the recent changes](https://github.com/fingerprintjs/fingerprintjs/pull/1045) to the FingerprintJS's contributing guide for Broyster.